### PR TITLE
Compile to Java 11 with module-info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,7 @@
   <properties>
     <packages.export>jakarta.inject.*</packages.export>
     <spec_version>2.0</spec_version>
-    <maven.compiler.source>9</maven.compiler.source>
-    <maven.compiler.target>9</maven.compiler.target>
+    <maven.compiler.release>9</maven.compiler.release>
   </properties>
 
   <build>
@@ -91,6 +90,11 @@
     </resources>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
   <properties>
     <packages.export>jakarta.inject.*</packages.export>
     <spec_version>2.0</spec_version>
-    <maven.compiler.release>9</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,8 @@
   <properties>
     <packages.export>jakarta.inject.*</packages.export>
     <spec_version>2.0</spec_version>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>9</maven.compiler.source>
+    <maven.compiler.target>9</maven.compiler.target>
   </properties>
 
   <build>
@@ -91,17 +91,6 @@
     </resources>
 
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>jakarta.inject</Automatic-Module-Name>
-            </manifestEntries>
-          </archive>
-        </configuration>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module jakarta.inject {
+    exports jakarta.inject;
+}


### PR DESCRIPTION
Removes Automatic-Module-Name manifest entry and replaces it with module-info