### PR TITLE
Change javadoc <tt> <code>

### DIFF
--- a/src/main/java/jakarta/inject/Inject.java
+++ b/src/main/java/jakarta/inject/Inject.java
@@ -36,24 +36,24 @@ import static java.lang.annotation.ElementType.FIELD;
  * zero or more dependencies as arguments. {@code @Inject} can apply to at most
  * one constructor per class.
  *
- * <blockquote><tt>@Inject
+ * <blockquote><code>@Inject
  *       <i>ConstructorModifiers<sub>opt</sub></i>
  *       <i>SimpleTypeName</i>(<i>FormalParameterList<sub>opt</sub></i>)
  *       <i>Throws<sub>opt</sub></i>
- *       <i>ConstructorBody</i></tt>
+ *       <i>ConstructorBody</i></code>
  *       </blockquote>
  *
  * <p>{@code @Inject} is optional for public, no-argument constructors when no
  * other constructors are present. This enables injectors to invoke default
  * constructors.
  *
- * <blockquote><tt>
+ * <blockquote><code>
  *       {@literal @}Inject<sub><i>opt</i></sub>
  *       <i>Annotations<sub>opt</sub></i>
  *       public
  *       <i>SimpleTypeName</i>()
  *       <i>Throws<sub>opt</sub></i>
- *       <i>ConstructorBody</i></tt>
+ *       <i>ConstructorBody</i></code>
  * </blockquote>
 
  * <p>Injectable fields:
@@ -62,10 +62,10 @@ import static java.lang.annotation.ElementType.FIELD;
  *   <li>are not final.
  *   <li>may have any otherwise valid name.</li></ul>
  *
- * <blockquote><tt>@Inject
+ * <blockquote><code>@Inject
  *       <i>FieldModifiers<sub>opt</sub></i>
  *       <i>Type</i>
- *       <i>VariableDeclarators</i>;</tt>
+ *       <i>VariableDeclarators</i>;</code>
  * </blockquote>
  *
  * <p>Injectable methods:
@@ -77,12 +77,12 @@ import static java.lang.annotation.ElementType.FIELD;
  *   <li>may have any otherwise valid name.</li>
  *   <li>accept zero or more dependencies as arguments.</li></ul>
  *
- * <blockquote><tt>@Inject
+ * <blockquote><code>@Inject
  *       <i>MethodModifiers<sub>opt</sub></i>
  *       <i>ResultType</i>
  *       <i>Identifier</i>(<i>FormalParameterList<sub>opt</sub></i>)
  *       <i>Throws<sub>opt</sub></i>
- *       <i>MethodBody</i></tt>
+ *       <i>MethodBody</i></code>
  * </blockquote>
  *
  * <p>The injector ignores the result of an injected method, but
@@ -111,7 +111,7 @@ import static java.lang.annotation.ElementType.FIELD;
  *
  * <p>Injection of members annotated with {@code @Inject} is required. While an
  * injectable member may use any accessibility modifier (including
- * <tt>private</tt>), platform or injector limitations (like security
+ * <code>private</code>), platform or injector limitations (like security
  * restrictions or lack of reflection support) might preclude injection
  * of non-public members.
  *

--- a/src/main/java/jakarta/inject/package-info.java
+++ b/src/main/java/jakarta/inject/package-info.java
@@ -21,8 +21,8 @@
  * locators (e.g., JNDI).&nbsp;This process, known as <i>dependency
  * injection</i>, is beneficial to most nontrivial applications.
  *
- * <p>Many types depend on other types. For example, a <tt>Stopwatch</tt> might
- * depend on a <tt>TimeSource</tt>. The types on which a type depends are
+ * <p>Many types depend on other types. For example, a <code>Stopwatch</code> might
+ * depend on a <code>TimeSource</code>. The types on which a type depends are
  * known as its <i>dependencies</i>. The process of finding an instance of a
  * dependency to use at run time is known as <i>resolving</i> the dependency.
  * If no such instance can be found, the dependency is said to be
@@ -100,7 +100,7 @@
  *
  * <p>The injector further passes dependencies to other dependencies until it
  * constructs the entire object graph. For example, suppose the programmer
- * asked an injector to create a <tt>StopwatchWidget</tt> instance:
+ * asked an injector to create a <code>StopwatchWidget</code> instance:
  *
  * <pre>   /** GUI for a Stopwatch &#42;/
  *   class StopwatchWidget {
@@ -110,9 +110,9 @@
  *
  * <p>The injector might:
  * <ol>
- *   <li>Find a <tt>TimeSource</tt>
- *   <li>Construct a <tt>Stopwatch</tt> with the <tt>TimeSource</tt>
- *   <li>Construct a <tt>StopwatchWidget</tt> with the <tt>Stopwatch</tt>
+ *   <li>Find a <code>TimeSource</code>
+ *   <li>Construct a <code>Stopwatch</code> with the <code>TimeSource</code>
+ *   <li>Construct a <code>StopwatchWidget</code> with the <code>Stopwatch</code>
  * </ol>
  *
  * <p>This leaves the programmer's code clean, flexible, and relatively free


### PR DESCRIPTION
Noting that `<tt>` is not valid in html5 and the suggestion is to change it to `<code>`

That is, when generating the javadoc for this project with JDK 11 javadoc we get the error - `tag not supported in the generated HTML version: tt`.  Changing the `<tt>` tag to `<code>` is the suggested fix.